### PR TITLE
Simplifies complicated AIGs more

### DIFF
--- a/aiger_abc/simplify.py
+++ b/aiger_abc/simplify.py
@@ -5,7 +5,7 @@ from subprocess import PIPE, call
 import aiger
 
 
-SIMPLIFY_TEMPLATE = 'read {0}; dc2; dc2; dc2; rewrite; write_aiger -s {0}'
+SIMPLIFY_TEMPLATE = 'read {0}; dc2; dc2; dc2; fraig; write_aiger -s {0}'
 
 
 def simplify(circ, verbose=False, abc_cmd='abc', aigtoaig_cmd='aigtoaig'):


### PR DESCRIPTION
ABC's fraig command simplifies complicated AIGs more than rewrite.

Alternatively, interleave "refactor" and "rewrite" with "balance". Per https://people.eecs.berkeley.edu/~alanmi/abc/abc.htm

> This section lists combinational synthesis commands implemented in the current release. Fast and efficient synthesis is achieved by DAG-aware rewriting of the AIG. Rewriting is performed using a library of pre-computed four-input AIGs (command rewrite; standard alias rw), or collapsing and refactoring of logic cones with 10-20 inputs (command refactor; standard alias rf). It can be experimentally shown that iterating these two transformations and interleaving them with AIG balancing (command balance; standard alias b) substantially reduces the AIG size and tends to reduce the number of AIG levels.